### PR TITLE
Pin Mermaid.js to exact version and add SRI integrity hash

### DIFF
--- a/MarkdigNative/Lib.cs
+++ b/MarkdigNative/Lib.cs
@@ -233,7 +233,7 @@ public static class Lib
             sb.Append("</style>");
             if (diagramsEnabled)
             {
-                sb.AppendLine("<script src='https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js' defer></script>");
+                sb.AppendLine("<script src='https://cdn.jsdelivr.net/npm/mermaid@10.9.3/dist/mermaid.min.js' integrity='sha256-Wo7JGCC9Va/vBJBoSJNpkQ5dbOcMgQOVLyfinT526Lw=' crossorigin='anonymous' defer></script>");
                 sb.AppendLine("<script>window.addEventListener('load',function(){if(window.mermaid){try{mermaid.initialize({startOnLoad:true,theme:'default'});}catch(e){}}});</script>");
             }
             sb.AppendLine("</head>");


### PR DESCRIPTION
## Изменения

  - Закреплена версия `Mermaid.js` с плавающей `@10` (последняя 10.x) на точную `@10.9.3`
  - Добавлены атрибуты `integrity` и `crossorigin` для проверки целостности скрипта (Subresource Integrity)

## Зачем

  CDN-тег скрипта использовал `mermaid@10`, который автоматически разрешается в последний релиз 10.x. Компрометация или ошибка на стороне upstream-пакета привела бы к незаметной подмене скрипта, выполняемого в WebView2 у каждого пользователя. SRI гарантирует, что браузер откажется выполнять скрипт, если его содержимое не совпадает с ожидаемым SHA-256 хешем.

## Проверка

  - Сборка: `dotnet publish MarkdigNative/MarkdigNative.csproj -c Release -r win-x64`
  - Открыть .md файл с блоком ` ```mermaid` в Total Commander — диаграмма отображается
  - (Опционально) Изменить хеш в Lib.cs на неверный, пересобрать — диаграмма НЕ должна отображаться, что подтверждает работу SRI
