### PR TITLE
Fix compiler warnings

### DIFF
--- a/MarkdigNative/Lib.cs
+++ b/MarkdigNative/Lib.cs
@@ -219,8 +219,8 @@ public static class Lib
 
             var pipeline = GetPipeline(extensions);
 
-            bool all = string.IsNullOrEmpty(extensions) || extensions.Contains("advanced", StringComparison.OrdinalIgnoreCase);
-            bool diagramsEnabled = all || extensions.Contains("diagrams", StringComparison.OrdinalIgnoreCase);
+            bool all = string.IsNullOrEmpty(extensions) || extensions!.Contains("advanced", StringComparison.OrdinalIgnoreCase);
+            bool diagramsEnabled = all || extensions!.Contains("diagrams", StringComparison.OrdinalIgnoreCase);
             string cssContent = GetCssContent(cssFile);
 
             var sb = new StringBuilder(source.Length + cssContent.Length + 2048);

--- a/MarkdownView/MarkdownView.vcxproj
+++ b/MarkdownView/MarkdownView.vcxproj
@@ -108,7 +108,7 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)Hoedown\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_WINDOWS;_USRDLL;HTMLVIEW_EXPORTS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader />
@@ -164,7 +164,7 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)Hoedown\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_WINDOWS;_USRDLL;HTMLVIEW_EXPORTS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader />

--- a/MarkdownView/browserhost.cpp
+++ b/MarkdownView/browserhost.cpp
@@ -796,7 +796,7 @@ void CBrowserHost::ClearSearchHighlight()
 	CComQIPtr<IHighlightRenderingServices> hl_services(html_disp);
 	if(!hl_services)
 		return;
-	int segm_count = mSearchHighlightSegments.size();
+	int segm_count = (int)mSearchHighlightSegments.size();
 	for(int i=0;i<segm_count;++i)
 		if(mSearchHighlightSegments[i])
 			hl_services->RemoveSegment(mSearchHighlightSegments[i]);
@@ -898,7 +898,7 @@ bool CBrowserHost::HighlightStrings(CComBSTR search, long search_flags)
 		mSearchHighlightSegments.push_back(hl_segment);
 		if(GetTickCount()>last_status_update_time+500)
 		{
-			SetStatusText(GetSearchStatusString(mSearchHighlightSegments.size(), false));
+			SetStatusText(GetSearchStatusString((int)mSearchHighlightSegments.size(), false));
 			last_status_update_time = GetTickCount();
 		}
 		long t;
@@ -908,7 +908,7 @@ bool CBrowserHost::HighlightStrings(CComBSTR search, long search_flags)
 		if(!t)
 			break;
 	}
-	SetStatusText(GetSearchStatusString(mSearchHighlightSegments.size(), true), 1000);
+	SetStatusText(GetSearchStatusString((int)mSearchHighlightSegments.size(), true), 1000);
 	return true;
 }
 
@@ -1098,7 +1098,7 @@ bool CBrowserHost::FindText(CComBSTR search, long search_flags, bool backward)
 			{
 				SetStatusText(GetSearchStatusString(-1, false));
 				UpdateSearchHighlight();
-				SetStatusText(GetSearchStatusString(mSearchHighlightSegments.size(), true), 1000);
+				SetStatusText(GetSearchStatusString((int)mSearchHighlightSegments.size(), true), 1000);
 			}
 			SetCurrentSearchHighlight(txt_range);
 		}
@@ -1226,7 +1226,7 @@ void RefreshBrowser(); // defined in main()
 void CBrowserHost::ProcessHotkey(UINT Msg, DWORD Key, DWORD Info)
 {
 	char str_action[80];
-	CAtlString full_name = GetFullKeyName(Key);
+	CAtlString full_name = GetFullKeyName((WORD)Key);
 	if((full_name=="F3" || full_name=="Shift+F3") && IsSearchHighlightEnabled())
 	{
 		if (mWebBrowser)
@@ -1377,7 +1377,7 @@ STDMETHODIMP CBrowserHost::QueryInterface(REFIID riid, void ** ppvObject)
     if(ppvObject == NULL) 
 		return E_INVALIDARG;
     else if(riid == IID_IUnknown)
-        *ppvObject = (IUnknown*)this;
+        *ppvObject = static_cast<IDispatch*>(this);
     else if(riid == IID_IDispatch)
 		*ppvObject = (IDispatch*)this;
     else if(riid == IID_IOleClientSite)

--- a/MarkdownView/browserhost.h
+++ b/MarkdownView/browserhost.h
@@ -17,11 +17,10 @@ enum FocusCatchType {fctNoCatch, fctQuickView, fctLister};
 //								CBrowserHost						   //
 //=====================================================================//
 
-class CBrowserHost : 
-	public IUnknown,
+class CBrowserHost :
 	public IDispatch,
 	public IOleControlSite,
-	public IOleClientSite, 
+	public IOleClientSite,
 	public IOleInPlaceSite
 {
 public:	

--- a/MarkdownView/functions.cpp
+++ b/MarkdownView/functions.cpp
@@ -189,11 +189,11 @@ void CSmallStringList::load_from_ini(const char* filename, const char* section, 
 		next_pos=strchr(str_pos+1, ';');
 		if(next_pos==NULL || next_pos==str_pos)
 			break;
-		*str_pos = next_pos-str_pos-1;
+		*str_pos = (char)(next_pos-str_pos-1);
 		str_pos = next_pos;
 	}
 	*str_pos = 0;
-	set_data((unsigned char*)buffer, str_pos-buffer+1);
+	set_data((unsigned char*)buffer, (int)(str_pos-buffer+1));
 }
 void CSmallStringList::load_sign_from_ini(const char* filename, const char* section, const char* key)
 {
@@ -211,27 +211,31 @@ void CSmallStringList::load_sign_from_ini(const char* filename, const char* sect
 			break;
 		if(*str_pos=='\"'&&*(next_pos-1)=='\"')
 		{
-			*list_pos = next_pos-str_pos-2;
+			*list_pos = (unsigned char)(next_pos-str_pos-2);
 			memcpy(list_pos+1, str_pos+1, *list_pos);
 			list_pos += *list_pos+1;
 		}
 		else
 		{
-			*list_pos = (next_pos-str_pos)/2;
+			*list_pos = (unsigned char)((next_pos-str_pos)/2);
 			for ( const char * s = str_pos; s<=next_pos-2; s += 2 )
-				sscanf(s, "%2x", ++list_pos);
+			{
+				unsigned int byte_val;
+				sscanf(s, "%2x", &byte_val);
+				*(++list_pos) = (unsigned char)byte_val;
+			}
 			++list_pos;
 		}
 		str_pos = next_pos+1;
 	}
 	*list_pos = 0;
-	set_data(list, list_pos-list+1);
+	set_data(list, (int)(list_pos-list+1));
 }
 bool CSmallStringList::find(const char* str)
 {
 	if(!valid())
 		return false;
-	int len = strlen(str);
+	int len = (int)strlen(str);
 	for(const unsigned char* str_pos = data; *str_pos; str_pos+=*str_pos+1)
 		if(*str_pos==len && !memcmp(str, str_pos+1, len))
 			return true;
@@ -262,7 +266,7 @@ bool CSmallStringList::check_signature(const char* filename, bool skip_spaces)
 				}
 			}
 		}
-		num_read = fread(buf, sizeof(unsigned char), *str_pos, file);
+		num_read = (int)fread(buf, sizeof(unsigned char), *str_pos, file);
 		if(num_read==*str_pos && !memicmp(buf, str_pos+1, *str_pos))
 		{
 			fclose(file);

--- a/MarkdownView/main.cpp
+++ b/MarkdownView/main.cpp
@@ -703,6 +703,7 @@ void InitProc()
 			OSVERSIONINFO osvi;
 			ZeroMemory(&osvi, sizeof(OSVERSIONINFO));
 			osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+			#pragma warning(suppress: 4996)
 			GetVersionEx(&osvi);
 			toolbar_bpp = (osvi.dwMajorVersion>5||osvi.dwMajorVersion==5&&osvi.dwMinorVersion>=1)?1:0;
 		}
@@ -923,7 +924,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			bool alt_down = 0x20000000&lParam;
 			bool key_down = 0x80000000&lParam;
 			UINT Msg = key_down?(alt_down?WM_SYSKEYUP:WM_KEYUP):(alt_down?WM_SYSKEYDOWN:WM_KEYDOWN);
-			CAtlString key_name = GetFullKeyName(wParam);
+			CAtlString key_name = GetFullKeyName((WORD)wParam);
 			if(key_name=="Ctrl+Insert")
 				SendMessage(hWnd, WM_IEVIEW_COMMAND, lc_copy, 0);
 			if(browser_host->FormFocused())
@@ -936,7 +937,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 				if(trans_hotkeys.find(key_name)&&!GetCapture()) 
 					SendMessage(hWnd, Msg, wParam, lParam);
 			}
-			browser_host->ProcessHotkey(Msg, wParam, lParam);
+			browser_host->ProcessHotkey(Msg, (DWORD)wParam, (DWORD)lParam);
 		}
 	}
 
@@ -1018,7 +1019,7 @@ void do_events()
 		result = ::GetMessage(&msg, NULL, 0, 0);
 		if (result == 0) // WM_QUIT
 		{
-			::PostQuitMessage(msg.wParam);
+			::PostQuitMessage((int)msg.wParam);
 			break;
 		}
 		else if (result == -1)


### PR DESCRIPTION
 ## Исправить предупреждения компилятора

  - `C4244`/`C4267` - усечение `size_t`/`ptrdiff_t`/`WPARAM`/`LPARAM` — явные приведения типов в `functions.cpp`, `browserhost.cpp`, `main.cpp`
  - `C4477` — `sscanf("%2x")` писал в `unsigned char*` вместо `unsigned int*`
  - `C4584` — удалён избыточный `IUnknown` из списка базовых классов `CBrowserHost`, `QueryInterface` приводит через `IDispatch*`
  - `CS8602` — null-forgiving оператор для `extensions` в `Lib.cs`
  - `D9035` — отключён устаревший флаг `/Gm` (MinimalRebuild) в `MarkdownView.vcxproj`
  - `C4996` — `GetVersionEx` deprecated, замены нет
