### PR TITLE
Fix build instructions in README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -101,10 +101,13 @@ Note: the C++ projects use Platform Toolset `v145`. If you have a different tool
 BuildAll.bat
 
 # Or build individually:
-# 1. Build .NET AOT component
-dotnet publish MarkdigNative/MarkdigNative.csproj -c Release
+# 1. Restore NuGet packages (WebView2 SDK)
+msbuild MarkdownView.sln -t:Restore
 
-# 2. Build C++ components
+# 2. Build .NET AOT component
+dotnet publish MarkdigNative/MarkdigNative.csproj -c Release -r win-x64
+
+# 3. Build C++ components
 msbuild MarkdownView.sln /p:Configuration=Release /p:Platform=x64
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -115,10 +115,13 @@ Target=auto
 BuildAll.bat
 
 # Или сборка по отдельности:
-# 1. Сборка .NET AOT компонента
-dotnet publish MarkdigNative/MarkdigNative.csproj -c Release
+# 1. Восстановление NuGet-пакетов (WebView2 SDK)
+msbuild MarkdownView.sln -t:Restore
 
-# 2. Сборка C++ компонентов
+# 2. Сборка .NET AOT компонента
+dotnet publish MarkdigNative/MarkdigNative.csproj -c Release -r win-x64
+
+# 3. Сборка C++ компонентов
 msbuild MarkdownView.sln /p:Configuration=Release /p:Platform=x64
 ```
 


### PR DESCRIPTION
##  Изменения

  - Добавлен шаг восстановления NuGet-пакетов (`msbuild -t:Restore`) в инструкции по сборке
  - Добавлен флаг `-r win-x64` к `dotnet publish` (обязателен для Native AOT)

##  Зачем

-  `WebView2 Runtime` не у всех стоит по умолчанию. Без `msbuild -t:Restore` сборка падает с ошибкой `Cannot open include file: 'WebView2.h'`
-  Без `-r win-x64 Native AOT` публикация не работает.

```
  MarkdigNative net8.0 failed with 1 error(s) and 1 warning(s) (2,5s) → MarkdigNative\bin\Release\net8.0\MarkdigNative.dll
    D:\code\wlx-markdown-viewer-github-style\MarkdigNative\Lib.cs(223,43): warning CS8602: Dereference of a possibly null reference.
     ~\.nuget\packages\microsoft.dotnet.ilcompiler\8.0.25\build\Microsoft.NETCore.Native.Publish.targets(49,5): error RuntimeIdentifier is required for native compilation. Try running dotnet publish with the -r option value specified.

Build failed with 1 error(s) and 1 warning(s) in 6,9s
```

##  Затронутые файлы

  - Readme.md (RU)
  - README.en.md (EN)
