### PR TITLE
Add missing BuildAll.bat script & CI/CD automations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,26 +20,8 @@ jobs:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
 
-      - name: Restore NuGet packages
-        run: msbuild MarkdownView.sln -t:Restore
-
-      - name: Build MarkdigNative (Native AOT x64)
-        run: dotnet publish MarkdigNative/MarkdigNative.csproj -c Release -r win-x64
-
-      - name: Build C++ components (x64)
-        run: msbuild MarkdownView.sln /p:Configuration=Release /p:Platform=x64
-
-      - name: Pack plugin
-        shell: bash
-        run: |
-          mkdir -p pack/css
-          cp Build/pluginst.inf pack/
-          cp Build/MarkdownView.ini pack/
-          cp Build/css/*.css pack/css/
-          cp bin/Release/MarkdownView.wlx64 pack/
-          cp bin/Release/Markdown-x64.dll pack/
-          cp MarkdigNative/bin/Release/net8.0/win-x64/publish/MarkdigNative-x64.dll pack/
-          cd pack && 7z a -tzip ../MarkdownViewGitHubStyle.zip *
+      - name: Build and pack
+        run: BuildAll.bat
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Restore NuGet packages
+        run: msbuild MarkdownView.sln -t:Restore
+
+      - name: Build MarkdigNative (Native AOT x64)
+        run: dotnet publish MarkdigNative/MarkdigNative.csproj -c Release -r win-x64
+
+      - name: Build C++ components (x64)
+        run: msbuild MarkdownView.sln /p:Configuration=Release /p:Platform=x64
+
+      - name: Pack plugin
+        shell: bash
+        run: |
+          mkdir -p pack/css
+          cp Build/pluginst.inf pack/
+          cp Build/MarkdownView.ini pack/
+          cp Build/css/*.css pack/css/
+          cp bin/Release/MarkdownView.wlx64 pack/
+          cp bin/Release/Markdown-x64.dll pack/
+          cp MarkdigNative/bin/Release/net8.0/win-x64/publish/MarkdigNative-x64.dll pack/
+          cd pack && 7z a -tzip ../MarkdownViewGitHubStyle.zip *
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: MarkdownViewGitHubStyle.zip
+          generate_release_notes: true

--- a/BuildAll.bat
+++ b/BuildAll.bat
@@ -25,7 +25,7 @@ copy bin\Release\Markdown-x64.dll pack\
 copy MarkdigNative\bin\Release\net8.0\win-x64\publish\MarkdigNative-x64.dll pack\
 
 pushd pack
-7z a -tzip ..\MarkdownViewGitHubStyle.zip *
+powershell -NoProfile -Command "Compress-Archive -Path '.\*' -DestinationPath '..\MarkdownViewGitHubStyle.zip' -Force"
 popd
 
 rd /s /q pack

--- a/BuildAll.bat
+++ b/BuildAll.bat
@@ -22,7 +22,7 @@ copy Build\MarkdownView.ini pack\
 copy Build\css\*.css pack\css\
 copy bin\Release\MarkdownView.wlx64 pack\
 copy bin\Release\Markdown-x64.dll pack\
-copy MarkdigNative\bin\Release\net8.0\win-x64\publish\MarkdigNative-x64.dll pack\
+copy MarkdigNative\bin\Release\net8.0\win-x64\publish\MarkdigNative.dll pack\MarkdigNative-x64.dll
 
 pushd pack
 powershell -NoProfile -Command "Compress-Archive -Path '.\*' -DestinationPath '..\MarkdownViewGitHubStyle.zip' -Force"

--- a/BuildAll.bat
+++ b/BuildAll.bat
@@ -1,0 +1,38 @@
+@echo off
+setlocal
+
+echo === Restore NuGet packages ===
+msbuild MarkdownView.sln -t:Restore
+if errorlevel 1 goto :fail
+
+echo === Build MarkdigNative (Native AOT x64) ===
+dotnet publish MarkdigNative/MarkdigNative.csproj -c Release -r win-x64
+if errorlevel 1 goto :fail
+
+echo === Build C++ components (x64) ===
+msbuild MarkdownView.sln /p:Configuration=Release /p:Platform=x64
+if errorlevel 1 goto :fail
+
+echo === Pack plugin ===
+if exist pack rd /s /q pack
+mkdir pack\css
+
+copy Build\pluginst.inf pack\
+copy Build\MarkdownView.ini pack\
+copy Build\css\*.css pack\css\
+copy bin\Release\MarkdownView.wlx64 pack\
+copy bin\Release\Markdown-x64.dll pack\
+copy MarkdigNative\bin\Release\net8.0\win-x64\publish\MarkdigNative-x64.dll pack\
+
+pushd pack
+7z a -tzip ..\MarkdownViewGitHubStyle.zip *
+popd
+
+rd /s /q pack
+
+echo === Done: MarkdownViewGitHubStyle.zip ===
+goto :eof
+
+:fail
+echo === Build failed ===
+exit /b 1


### PR DESCRIPTION
 ## Изменения
  - `BuildAll.bat` — скрипт полного цикла: NuGet restore, сборка AOT + C++, упаковка в ZIP
  - `.github/workflows/release.yml` — CI workflow, вызывает `BuildAll.bat` и публикует релиз

  ## Локальная сборка
  BuildAll.bat
  Результат: `MarkdownViewGitHubStyle.zip` в корне репозитория.

  ## Автоматический релиз
  git tag v1.0.0
  git push origin v1.0.0
  GitHub Actions соберет плагин и создаст релиз с прикрепленным ZIP.

  ## Проверка
  - [ ] Локально: `BuildAll.bat` завершается без ошибок, ZIP содержит `wlx64`, обе DLL, INI, CSS
  - [ ] CI: пуш тега создает релиз с рабочим архивом
  - [ ] Скачать ZIP, открыть в TC — плагин устанавливается