### PR TITLE
Fix hotkey handling within WebView frame

### DIFF
--- a/MarkdownView/browserhost.cpp
+++ b/MarkdownView/browserhost.cpp
@@ -246,6 +246,31 @@ bool CBrowserHost::CreateBrowser(HWND hParent)
 			}
 		}
 
+		// Forward keys from WebView2 to the plugin window so TC hotkeys (ESC, F3, etc.) work.
+		// WebView2 runs out-of-process, so WH_KEYBOARD hooks never see its keystrokes.
+		mWebViewController->add_AcceleratorKeyPressed(
+			Callback<ICoreWebView2AcceleratorKeyPressedEventHandler>(
+				[this](ICoreWebView2Controller* sender, ICoreWebView2AcceleratorKeyPressedEventArgs* args) -> HRESULT {
+					COREWEBVIEW2_KEY_EVENT_KIND kind;
+					args->get_KeyEventKind(&kind);
+					if (kind != COREWEBVIEW2_KEY_EVENT_KIND_KEY_DOWN &&
+						kind != COREWEBVIEW2_KEY_EVENT_KIND_SYSTEM_KEY_DOWN)
+						return S_OK;
+
+					UINT key;
+					args->get_VirtualKey(&key);
+
+					CAtlString key_name = GetFullKeyName((WORD)key);
+					if (trans_hotkeys.find(key_name) && !GetCapture())
+					{
+						args->put_Handled(TRUE);
+						UINT msg = (kind == COREWEBVIEW2_KEY_EVENT_KIND_SYSTEM_KEY_DOWN) ? WM_SYSKEYDOWN : WM_KEYDOWN;
+						PostMessage(mParentWin, msg, key, 0);
+					}
+					return S_OK;
+				}).Get(),
+			nullptr);
+
 		UpdateFolderMapping(mCurrentFolder);
 		Resize();
 

--- a/MarkdownView/functions.h
+++ b/MarkdownView/functions.h
@@ -71,6 +71,7 @@ struct SOptions
 };
 extern SOptions options;
 extern HINSTANCE hinst;
+extern CSmallStringList trans_hotkeys;
 
 void InitOptions();
 void InitProc();


### PR DESCRIPTION
  ## Исправить работу горячих клавиш при фокусе на WebView2

  ### Проблема
  После клика в область отрендеренного Markdown фокус переходит в WebView2 (Chromium-процесс). Горячие клавиши Total Commander (ESC, F3, цифры и т.д.) перестают работать, т.к. `WH_KEYBOARD` хук перехватывает нажатия только в потоке TC, а WebView2 работает в отдельном процессе.

  ### Решение
  Добавлен обработчик `add_AcceleratorKeyPressed` на WebView2 контроллере. При нажатии клавиши, входящей в список `TranslationHotkeys` из INI, нажатие помечается как обработанное и пробрасывается через `PostMessage` в родительское окно плагина, где TC обрабатывает его штатным образом.

  ### Затронутые файлы
  - `MarkdownView/browserhost.cpp` — обработчик `AcceleratorKeyPressed`
  - `MarkdownView/functions.h` — `extern` для `trans_hotkeys`
